### PR TITLE
Verbose error reporting on setting custom field values

### DIFF
--- a/source/encoder.cpp
+++ b/source/encoder.cpp
@@ -1003,8 +1003,11 @@ bool obsffmpeg::encoder::update(obs_data_t* settings)
 						if ((ret = av_opt_set(_context, key.c_str(), value.c_str(),
 						                      AV_OPT_SEARCH_CHILDREN))
 						    < 0) {
-							PLOG_WARNING("Option '%s' could not be set to '%s'.",
-							             key.c_str(), value.c_str());
+							char sterror[AV_ERROR_MAX_STRING_SIZE];
+							av_make_error_string(sterror, AV_ERROR_MAX_STRING_SIZE, ret);
+							PLOG_WARNING("Option '%s' could not be set to '%s'. (%s)", key.c_str(), value.c_str(), sterror);
+						} else {
+							PLOG_WARNING("Option '%s' set to '%s'.", key.c_str(), value.c_str());
 						}
 						have_param      = false;
 						have_key        = false;

--- a/source/encoder.cpp
+++ b/source/encoder.cpp
@@ -1006,8 +1006,6 @@ bool obsffmpeg::encoder::update(obs_data_t* settings)
 							char sterror[AV_ERROR_MAX_STRING_SIZE];
 							av_make_error_string(sterror, AV_ERROR_MAX_STRING_SIZE, ret);
 							PLOG_WARNING("Option '%s' could not be set to '%s'. (%s)", key.c_str(), value.c_str(), sterror);
-						} else {
-							PLOG_WARNING("Option '%s' set to '%s'.", key.c_str(), value.c_str());
 						}
 						have_param      = false;
 						have_key        = false;


### PR DESCRIPTION
### Description
source/encoder.cpp: Added a call to convert error number into meaninnful text, showed this error for every failed custom field passed, also shows every successfully set custom field passed.
```
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc] Initializing...
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Video Input: 1920x1080 nv12 BT.601 625 Partial
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Video Output: 1920x1080 nv12 BT.601 625 Partial
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Framerate: 120/1 (120.000000 FPS)
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Custom Settings: -gpu=1 -trouble=true
15:22:08.000: [obs-ffmpeg-encoder] Option 'gpu' set to '1'.
15:22:08.000: [obs-ffmpeg-encoder] Option 'trouble' could not be set to 'true'. (Option not found)
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Preset: default
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Rate Control: cbr_hq
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]     Two Pass: Default
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]     Lookahead: 0 Frames
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Buffer Size: 12000
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Bitrate Target: 6000
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Spatial AQ Enabled: Strength 8
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   Temporal AQ Enabled
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   B-Frames: 2
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]     Reference Mode: disabled
15:22:08.000: [obs-ffmpeg-encoder] [h264_nvenc]   H.264 Profile: high

```
### Motivation and Context
Trying to find out what settings were set and which ones were not set is a long trial and error proccess, this should help remove the guess work out of using the custom field parameters.

### How Has This Been Tested?
I have used those changes in a local OBS setup

### Types of changes
New feature

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
